### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ compatible with OSS Memcached protocol.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-memcache.svg
    :target: https://pypi.org/project/google-cloud-memcache/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-memcache.svg
@@ -80,4 +80,4 @@ Next Steps
    APIs that we cover.
 
 .. _Cloud Memorystore for Memcached API Product documentation:  https://cloud.google.com/memorystore/docs/memcached/
-.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.