### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "memcache",
     "name_pretty": "Cloud Memorystore for Memcached",
     "product_documentation": "cloud.google.com/memorystore/docs/memcached/",
-    "client_documentation": "https://googleapis.dev/python/memcache/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/memcache/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ compatible with OSS Memcached protocol.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-memcache.svg
    :target: https://pypi.org/project/google-cloud-memcache/
 .. _Cloud Memorystore for Memached API: https://cloud.google.com/memorystore/docs/memcached/
-.. _Client Library Documentation: https://googleapis.dev/python/memcache/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/memcache/latest
 .. _Product Documentation:  https://cloud.google.com/memorystore/docs/memcached/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.